### PR TITLE
Remove broken style

### DIFF
--- a/customChrome.css
+++ b/customChrome.css
@@ -1,4 +1,6 @@
 /* My configuration is going here to make merges easier. I'm testing this with NixOS currently.
 This will probably be replaced with a more nixos-like system in the future */
-@import "ui/gnome-3.26-light.css";
-/*@import "ui/csd.css";*/
+@import "ui/gnome-3.26-dark.css";
+@import "ui/hide-single-tab.css";
+@import "ui/matching-autocomplete-width.css";
+/*@import "ui/csd.css"; TODO*/

--- a/customChrome.css
+++ b/customChrome.css
@@ -1,0 +1,4 @@
+/* My configuration is going here to make merges easier. I'm testing this with NixOS currently.
+This will probably be replaced with a more nixos-like system in the future */
+@import "ui/gnome-3.26-light.css";
+@import "ui/csd.css";

--- a/customChrome.css
+++ b/customChrome.css
@@ -4,3 +4,8 @@ This will probably be replaced with a more nixos-like system in the future */
 @import "ui/hide-single-tab.css";
 @import "ui/matching-autocomplete-width.css";
 /*@import "ui/csd.css"; TODO*/
+
+input, select {
+  color: white;
+  background-color: black;
+}

--- a/customChrome.css
+++ b/customChrome.css
@@ -1,4 +1,4 @@
 /* My configuration is going here to make merges easier. I'm testing this with NixOS currently.
 This will probably be replaced with a more nixos-like system in the future */
 @import "ui/gnome-3.26-light.css";
-@import "ui/csd.css";
+/*@import "ui/csd.css";*/

--- a/customContent.css
+++ b/customContent.css
@@ -1,0 +1,8 @@
+@import "pages/about-dark.css";
+@import "pages/view-source-dark.css";
+
+/* Fix input colors */
+input, textarea, select {
+  background: white;
+  color: black;
+}

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -356,14 +356,14 @@ panel[type=arrow][viewId=PanelUI-developer],
 #urlbar[focused] .urlbar-textbox-container {
 	margin: -1px !important;
 }
-#urlbar-container {
-	/* smaller URL bar? */
+/*#urlbar-container {
+	/* smaller URL bar? 
 	max-width: calc(129ch + 24px + 2 * var(--toolbarbutton-inner-padding)) !important;
 }
 toolbarspring {
-	/* center the URL bar */
+	/* center the URL bar 
 	max-width: 10000px !important;
-}
+}*/
 #urlbar .urlbar-textbox-container {
 	background-image: var(--gnome-urlbar-bgimage);
 }

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -356,10 +356,6 @@ panel[type=arrow][viewId=PanelUI-developer],
 #urlbar[focused] .urlbar-textbox-container {
 	margin: -1px !important;
 }
-#urlbar-container {
-	/* smaller URL bar? */
-	max-width: calc(129ch + 24px + 2 * var(--toolbarbutton-inner-padding)) !important;
-}
 toolbarspring {
 	/* center the URL bar */
 	max-width: 10000px !important;


### PR DESCRIPTION
With this style present, Firefox looks broken if there are no flexible spaces around the URL bar (my preferred configuration). Removing this line fixes the issue.

**Before:**
![image](https://user-images.githubusercontent.com/11251606/37319821-0c50a646-2647-11e8-9959-5f787b71c999.png)

**After:**
![image](https://user-images.githubusercontent.com/11251606/37319844-2bd7e4f2-2647-11e8-8595-328f98328738.png)

**Before with spacers:**
![image](https://user-images.githubusercontent.com/11251606/37374054-bbd68a56-26ef-11e8-887a-288919ad6a54.png)

**After with spacers:**
![image](https://user-images.githubusercontent.com/11251606/37374088-ddbc6f78-26ef-11e8-983a-874571de7cab.png)