### PR TITLE
Remove broken style

### DIFF
--- a/ui/theme.css
+++ b/ui/theme.css
@@ -356,10 +356,6 @@ panel[type=arrow][viewId=PanelUI-developer],
 #urlbar[focused] .urlbar-textbox-container {
 	margin: -1px !important;
 }
-#urlbar-container {
-	/* smaller URL bar? */
-	max-width: calc(129ch + 24px + 2 * var(--toolbarbutton-inner-padding)) !important;
-}
 toolbarspring {
 	/* center the URL bar */
 	max-width: 10000px !important;


### PR DESCRIPTION
*I fixed the commits issue with my previous PR. I have also included images of both configurations with flexible spaces included. As you can see, it basically looks identical.*

With this style present, Firefox looks broken if there are no flexible spaces around the URL bar (my preferred configuration). Removing this line fixes the issue.

**Before:**
![image](https://user-images.githubusercontent.com/11251606/37319821-0c50a646-2647-11e8-9959-5f787b71c999.png)

**After:**
![image](https://user-images.githubusercontent.com/11251606/37319844-2bd7e4f2-2647-11e8-8595-328f98328738.png)

**Before with spacers:**
![image](https://user-images.githubusercontent.com/11251606/37374054-bbd68a56-26ef-11e8-887a-288919ad6a54.png)

**After with spacers:**
![image](https://user-images.githubusercontent.com/11251606/37374088-ddbc6f78-26ef-11e8-983a-874571de7cab.png)