### PR TITLE
CSD improvements to FF 60+

### DIFF
--- a/ui/experimental-auto-csd.css
+++ b/ui/experimental-auto-csd.css
@@ -19,14 +19,6 @@
 	overflow: hidden;
 }
 
-:root[tabsintitlebar] #nav-bar toolbarbutton.chromeclass-toolbar-additional,
-:root[tabsintitlebar] #nav-bar toolbarbutton.toolbarbutton-combined,
-:root[tabsintitlebar] #nav-bar #reload-button,
-:root[tabsintitlebar] #nav-bar #stop-button,
-:root[tabsintitlebar] #PanelUI-menu-button {
-	margin: 6px 3px !important;
-}
-
 :root[tabsintitlebar] #nav-bar {
 	margin-top: -47px !important;
 	padding-right: 7px !important;
@@ -141,4 +133,25 @@
 /* Fix the issue when dragging tabs */
 :root[tabsintitlebar] #TabsToolbar[movingtab] + #nav-bar {
 	margin-top: -47px !important;
+}
+
+/* Window controls: at least 1 button */
+@media (-moz-gtk-csd-minimize-button), (-moz-gtk-csd-maximize-button), (-moz-gtk-csd-close-button) {
+    :root[tabsintitlebar] #nav-bar {
+	    margin-right: 43px;
+    }
+}
+/* Window controls: at least 2 buttons */
+@media (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-maximize-button),
+       (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-close-button),
+       (-moz-gtk-csd-maximize-button) and (-moz-gtk-csd-close-button) {
+    :root[tabsintitlebar] #nav-bar {
+	    margin-right: 83px;
+    }
+}
+/* Window controls: 3 buttons */
+@media (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-maximize-button) and (-moz-gtk-csd-close-button) {
+    :root[tabsintitlebar] #nav-bar {
+	    margin-right: 123px;
+    }
 }

--- a/ui/experimental-auto-csd.css
+++ b/ui/experimental-auto-csd.css
@@ -1,0 +1,144 @@
+@namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+
+/* An ugly hack to add rounded corners to the headerbar
+ * TODO remove it when this gets fixed:
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1408360
+ * width=960 - horizontally half the screen (1920x1080)
+ * height=1053 - vertically maximized (1920x1080) */
+:root[tabsintitlebar] window:not([width="960"]):not([height="1053"]) #nav-bar {
+	border-top-left-radius: 8px;
+}
+:root[tabsintitlebar] window:not([width="960"]):not([height="1053"]) #titlebar-buttonbox {
+	border-top-right-radius: 8px;
+}
+
+:root[tabsintitlebar] #titlebar {
+	height: 52px !important;
+	margin-bottom: 0px !important;
+	margin-right: -4px;
+	overflow: hidden;
+}
+
+:root[tabsintitlebar] #nav-bar toolbarbutton.chromeclass-toolbar-additional,
+:root[tabsintitlebar] #nav-bar toolbarbutton.toolbarbutton-combined,
+:root[tabsintitlebar] #nav-bar #reload-button,
+:root[tabsintitlebar] #nav-bar #stop-button,
+:root[tabsintitlebar] #PanelUI-menu-button {
+	margin: 6px 3px !important;
+}
+
+:root[tabsintitlebar] #nav-bar {
+	margin-top: -47px !important;
+	padding-right: 7px !important;
+	position: relative;
+}
+
+:root[tabsintitlebar] #toolbar-menubar {
+	padding-bottom: 0 !important;
+}
+
+/* Add window controls separator */
+:root[tabsintitlebar] #nav-bar::after {
+	content: "";
+	position: absolute;
+	right: 3px;
+	top: 6px;
+	height: 32px;
+	border-right: 1px solid rgba(0, 0, 0, .1);
+}
+
+/* Move window buttons next to the header bar */
+:root[tabsintitlebar] #titlebar-buttonbox {
+	background-image: var(--gnome-headerbar-bgimage) !important;
+	border: none !important;
+	border-bottom: var(--gnome-headerbar-border-bottom) !important;
+	box-shadow: var(--gnome-headerbar-box-shadow);
+	height: unset !important;
+	margin-top: 0 !important;
+	padding-bottom: 0 !important;
+	padding-right: 3px;
+	padding-top: 0 !important;
+}
+
+:root[tabsintitlebar] #titlebar-buttonbox:-moz-window-inactive {
+	background-image: var(--gnome-inactive-headerbar-bgimage) !important;
+	border-bottom: var(--gnome-inactive-headerbar-border-bottom) !important;
+	box-shadow: var(--gnome-inactive-headerbar-box-shadow);
+}
+:root[tabsintitlebar] #navigator-toolbox {
+	margin-top: -5px;
+}
+
+/* Window buttons */
+:root[tabsintitlebar] #titlebar toolbarbutton {
+	-moz-appearance: none !important;
+	border: var(--gnome-headerbar-button-border) !important;
+	border-color: transparent !important;
+	border-radius: 3px !important;
+	height: 34px;
+	margin: 6px 3px !important;
+	padding: 0 2px !important;
+	position: relative;
+	transition: all .3s ease-out;
+	width: 34px;
+}
+:root[tabsintitlebar] #titlebar toolbarbutton image {
+	filter: invert(85%);
+	margin-left: 6px;
+}
+:root[tabsintitlebar] #titlebar:-moz-window-inactive toolbarbutton image {
+	opacity: .7 !important;
+}
+:root[tabsintitlebar] #titlebar:not(:-moz-window-inactive) toolbarbutton:not([disabled]):hover {
+	background-image: var(--gnome-headerbar-button-hover-bgimage);
+	border: var(--gnome-headerbar-button-border) !important;
+}
+:root[tabsintitlebar] #titlebar:not(:-moz-window-inactive) toolbarbutton:not([disabled]):active {
+	background-image: var(--gnome-headerbar-button-active-bgimage);
+	box-shadow: var(--gnome-headerbar-button-active-box-shadow);
+	border: var(--gnome-headerbar-button-border) !important;
+}
+:root[tabsintitlebar] #titlebar:not(:-moz-window-inactive) toolbarbutton[disabled] {
+	background-color: var(--gnome-headerbar-button-disabled-bgcolor);
+	box-shadow: var(--gnome-headerbar-button-disabled-box-shadow);
+	border: var(--gnome-headerbar-button-border) !important;
+}
+
+:root[tabsintitlebar] #titlebar-close .toolbarbutton-icon {
+	filter: var(--gnome-icons-hack-filter);
+	list-style-image: url("moz-icon://stock/window-close-symbolic?size=menu") !important;
+}
+:root[tabsintitlebar] #titlebar-max .toolbarbutton-icon {
+	filter: var(--gnome-icons-hack-filter);
+	list-style-image: url("moz-icon://stock/window-maximize-symbolic?size=menu") !important;
+}
+:root[tabsintitlebar] #titlebar-min .toolbarbutton-icon {
+	filter: var(--gnome-icons-hack-filter);
+	list-style-image: url("moz-icon://stock/window-minimize-symbolic?size=menu") !important;
+}
+
+/* Remove ugly line before tabs */
+:root[tabsintitlebar] .titlebar-placeholder[type="pre-tabs"] {
+	border-inline-end: 0px solid !important;
+}
+
+/* Remove blank space after tabs when window is maximized */
+:root[tabsintitlebar] #main-window:not([sizemode="normal"]) .titlebar-placeholder[type="post-tabs"] {
+	display: none !important;
+}
+
+/* Remove window controls blank space after tabs */
+:root[tabsintitlebar] .titlebar-placeholder[type="caption-buttons"] {
+	display: none !important;
+}
+
+/* Remove blank space before and after tabs */
+:root[tabsintitlebar] .titlebar-placeholder[type="pre-tabs"],
+:root[tabsintitlebar] .titlebar-placeholder[type="post-tabs"] {
+	display: none !important;
+}
+
+/* Fix the issue when dragging tabs */
+:root[tabsintitlebar] #TabsToolbar[movingtab] + #nav-bar {
+	margin-top: -47px !important;
+}

--- a/ui/experimental-ff-60-csd.css
+++ b/ui/experimental-ff-60-csd.css
@@ -1,29 +1,109 @@
-@import "csd.css";
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+/* An ugly hack to add rounded corners to the headerbar
+ * TODO remove it when this gets fixed:
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1408360
+ * width=960 - horizontally half the screen (1920x1080)
+ * height=1053 - vertically maximized (1920x1080) */
+window:not([width="960"]):not([height="1053"]) #nav-bar {
+	border-top-left-radius: 8px;
+}
+window:not([width="960"]):not([height="1053"]) #titlebar-buttonbox {
+	border-top-right-radius: 8px;
+}
+
 #titlebar {
-	margin-bottom: -47px !important;
+	height: 52px !important;
+	margin-bottom: 0px !important;
+	margin-right: -4px;
+	overflow: hidden;
+}
+
+#nav-bar toolbarbutton.chromeclass-toolbar-additional,
+#nav-bar toolbarbutton.toolbarbutton-combined,
+#nav-bar #reload-button,
+#nav-bar #stop-button,
+#PanelUI-menu-button {
+	margin: 6px 3px !important;
 }
 
 #nav-bar {
-	margin-top: 5px !important;
+	margin-top: -47px !important;
+	padding-right: 7px !important;
+	position: relative;
 }
 
+#toolbar-menubar {
+	padding-bottom: 0 !important;
+}
+
+/* Add window controls separator */
+#nav-bar::after {
+	content: "";
+	position: absolute;
+	right: 3px;
+	top: 6px;
+	height: 32px;
+	border-right: 1px solid rgba(0, 0, 0, .1);
+}
+
+/* Move window buttons next to the header bar */
 #titlebar-buttonbox {
+	background-image: var(--gnome-headerbar-bgimage) !important;
+	border: none !important;
+	border-bottom: var(--gnome-headerbar-border-bottom) !important;
+	box-shadow: var(--gnome-headerbar-box-shadow);
 	height: unset !important;
 	margin-top: 0 !important;
+	padding-bottom: 0 !important;
+	padding-right: 3px;
+	padding-top: 0 !important;
 }
 
+#titlebar-buttonbox:-moz-window-inactive {
+	background-image: var(--gnome-inactive-headerbar-bgimage) !important;
+	border-bottom: var(--gnome-inactive-headerbar-border-bottom) !important;
+	box-shadow: var(--gnome-inactive-headerbar-box-shadow);
+}
+#navigator-toolbox {
+	margin-top: -5px;
+}
+
+/* Window buttons */
 #titlebar toolbarbutton {
-	margin: 4px 3px !important;
+	-moz-appearance: none !important;
+	border: var(--gnome-headerbar-button-border) !important;
+	border-color: transparent !important;
+	border-radius: 3px !important;
+	height: 34px;
+	margin: 6px 3px !important;
+	padding: 0 2px !important;
+	position: relative;
+	transition: all .3s ease-out;
+	width: 34px;
+}
+#titlebar toolbarbutton image {
+	filter: invert(85%);
+	margin-left: 6px;
+}
+#titlebar:-moz-window-inactive toolbarbutton image {
+	opacity: .7 !important;
+}
+#titlebar:not(:-moz-window-inactive) toolbarbutton:not([disabled]):hover {
+	background-image: var(--gnome-headerbar-button-hover-bgimage);
+	border: var(--gnome-headerbar-button-border) !important;
+}
+#titlebar:not(:-moz-window-inactive) toolbarbutton:not([disabled]):active {
+	background-image: var(--gnome-headerbar-button-active-bgimage);
+	box-shadow: var(--gnome-headerbar-button-active-box-shadow);
+	border: var(--gnome-headerbar-button-border) !important;
+}
+#titlebar:not(:-moz-window-inactive) toolbarbutton[disabled] {
+	background-color: var(--gnome-headerbar-button-disabled-bgcolor);
+	box-shadow: var(--gnome-headerbar-button-disabled-box-shadow);
+	border: var(--gnome-headerbar-button-border) !important;
 }
 
-/* Fix the issue when dragging tabs */
-#TabsToolbar[movingtab] + #nav-bar {
-	margin-top: 5px !important;
-}
-
-/* TODO icons don't have proper color */
 #titlebar-close .toolbarbutton-icon {
 	filter: var(--gnome-icons-hack-filter);
 	list-style-image: url("moz-icon://stock/window-close-symbolic?size=menu") !important;
@@ -35,4 +115,30 @@
 #titlebar-min .toolbarbutton-icon {
 	filter: var(--gnome-icons-hack-filter);
 	list-style-image: url("moz-icon://stock/window-minimize-symbolic?size=menu") !important;
+}
+
+/* Remove ugly line before tabs */
+.titlebar-placeholder[type="pre-tabs"] {
+	border-inline-end: 0px solid !important;
+}
+
+/* Remove blank space after tabs when window is maximized */
+#main-window:not([sizemode="normal"]) .titlebar-placeholder[type="post-tabs"] {
+	display: none !important;
+}
+
+/* Remove window controls blank space after tabs */
+.titlebar-placeholder[type="caption-buttons"] {
+	display: none !important;
+}
+
+/* Remove blank space before and after tabs */
+.titlebar-placeholder[type="pre-tabs"],
+.titlebar-placeholder[type="post-tabs"] {
+	display: none !important;
+}
+
+/* Fix the issue when dragging tabs */
+#TabsToolbar[movingtab] + #nav-bar {
+	margin-top: -47px !important;
 }


### PR DESCRIPTION
Before merging this, we should tag FF 59.

**Description of the Change:**
- Fix #39.
- Improve a little bit the code.
- Merge  `csd.css` with `experimental-ff-60-csd.css`.

After merging this, we should overwrite `csd.css` with `experimental-ff-60-csd.css`.
_Tested on FF 60 & 62._